### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # The Amazing Mustermann
 
 [![Build Status](https://travis-ci.org/rkh/mustermann.png?branch=master)](https://travis-ci.org/rkh/mustermann) [![Coverage Status](https://coveralls.io/repos/rkh/mustermann/badge.png?branch=master)](https://coveralls.io/r/rkh/mustermann) [![Code Climate](https://codeclimate.com/github/rkh/mustermann.png)](https://codeclimate.com/github/rkh/mustermann) [![Dependency Status](https://gemnasium.com/rkh/mustermann.png)](https://gemnasium.com/rkh/mustermann) [![Gem Version](https://badge.fury.io/rb/mustermann.png)](http://badge.fury.io/rb/mustermann)
+[![Inline docs](http://inch-pages.github.io/github/rkh/mustermann.png)](http://inch-pages.github.io/github/rkh/mustermann)
 [![Documentation](http://b.repl.ca/v1/yard-docs-blue.png)](http://rubydoc.info/gems/mustermann/frames)
 
 *Make sure you view the correct docs: [latest release](http://rubydoc.info/gems/mustermann/frames), [master](http://rubydoc.info/github/rkh/mustermann/master/frames).*


### PR DESCRIPTION
Hi Konstantin,

this patch adds an alternative docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/rkh/mustermann.png)](http://inch-pages.github.io/github/rkh/mustermann) 

The badge shows an evaluation of the present inline-docs in your project and links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. The status page for Mustermann is http://inch-pages.github.io/github/rkh/mustermann/

Inch Pages is still in it's infancy, but already used by projects like [Guard](https://github.com/guard/guard) and [Pry](https://github.com/pry/pry).

What do you think?

P.S. I wanted to leave it to you to decide whether or not this patch, if accepted, makes the present yardoc badge obsolete.
