### PR TITLE
Fix simplecov multiformatter deprecation warning

### DIFF
--- a/support/lib/support/coverage.rb
+++ b/support/lib/support/coverage.rb
@@ -2,10 +2,12 @@ require 'simplecov'
 require 'coveralls'
 require 'support/projects'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-]
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [
+    SimpleCov::Formatter::HTMLFormatter,
+    Coveralls::SimpleCov::Formatter
+  ]
+)
 
 SimpleCov.start do
   project_name 'mustermann'


### PR DESCRIPTION
`coverage.rb:5:in <top (required)>': [DEPRECATION] ::[] is deprecated. Use ::new instead.`