### PR TITLE
Use and support frozen string literals everywhere

### DIFF
--- a/mustermann-contrib/lib/mustermann/cake.rb
+++ b/mustermann-contrib/lib/mustermann/cake.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann'
 require 'mustermann/ast/pattern'
 

--- a/mustermann-contrib/lib/mustermann/express.rb
+++ b/mustermann-contrib/lib/mustermann/express.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann'
 require 'mustermann/ast/pattern'
 

--- a/mustermann-contrib/lib/mustermann/file_utils.rb
+++ b/mustermann-contrib/lib/mustermann/file_utils.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann'
 require 'mustermann/file_utils/glob_pattern'
 require 'mustermann/mapper'

--- a/mustermann-contrib/lib/mustermann/file_utils/glob_pattern.rb
+++ b/mustermann-contrib/lib/mustermann/file_utils/glob_pattern.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/ast/translator'
 
 module Mustermann

--- a/mustermann-contrib/lib/mustermann/flask.rb
+++ b/mustermann-contrib/lib/mustermann/flask.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann'
 require 'mustermann/ast/pattern'
 

--- a/mustermann-contrib/lib/mustermann/pyramid.rb
+++ b/mustermann-contrib/lib/mustermann/pyramid.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann'
 require 'mustermann/ast/pattern'
 

--- a/mustermann-contrib/lib/mustermann/rails.rb
+++ b/mustermann-contrib/lib/mustermann/rails.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann'
 require 'mustermann/ast/pattern'
 require 'mustermann/versions'

--- a/mustermann-contrib/lib/mustermann/shell.rb
+++ b/mustermann-contrib/lib/mustermann/shell.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann'
 require 'mustermann/pattern'
 require 'mustermann/simple_match'

--- a/mustermann-contrib/lib/mustermann/simple.rb
+++ b/mustermann-contrib/lib/mustermann/simple.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann'
 require 'mustermann/regexp_based'
 

--- a/mustermann-contrib/lib/mustermann/string_scanner.rb
+++ b/mustermann-contrib/lib/mustermann/string_scanner.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann'
 require 'mustermann/pattern_cache'
 require 'delegate'

--- a/mustermann-contrib/lib/mustermann/template.rb
+++ b/mustermann-contrib/lib/mustermann/template.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann'
 require 'mustermann/ast/pattern'
 

--- a/mustermann-contrib/lib/mustermann/versions.rb
+++ b/mustermann-contrib/lib/mustermann/versions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mustermann
   # Mixin that adds support for multiple versions of the same type.
   # @see Mustermann::Rails

--- a/mustermann-contrib/lib/mustermann/visualizer.rb
+++ b/mustermann-contrib/lib/mustermann/visualizer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann'
 require 'mustermann/visualizer/highlight'
 require 'mustermann/visualizer/tree_renderer'
@@ -10,10 +11,10 @@ module Mustermann
 
     # @example creating a highlight object
     #   require 'mustermann/visualizer'
-    #   
+    #
     #   pattern   = Mustermann.new('/:name')
     #   highlight = Mustermann::Visualizer.highlight(pattern)
-    #   
+    #
     #   puts highlight.to_ansi
     #
     # @return [Mustermann::Visualizer::Highlight] highlight object for given pattern
@@ -24,10 +25,10 @@ module Mustermann
 
     # @example creating a tree object
     #   require 'mustermann/visualizer'
-    #   
+    #
     #   pattern = Mustermann.new('/:name')
     #   tree    = Mustermann::Visualizer.tree(pattern)
-    #   
+    #
     #   puts highlight.to_s
     #
     # @return [Mustermann::Visualizer::Tree] tree object for given pattern

--- a/mustermann-contrib/lib/mustermann/visualizer/highlight.rb
+++ b/mustermann-contrib/lib/mustermann/visualizer/highlight.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hansi'
 require 'mustermann'
 require 'mustermann/visualizer/highlighter'
@@ -57,10 +58,10 @@ module Mustermann
 
       # @example
       #   require 'mustermann/visualizer'
-      #   
+      #
       #   pattern   = Mustermann.new('/:name')
       #   highlight = Mustermann::Visualizer.highlight(pattern)
-      #   
+      #
       #   puts highlight.to_hansi_template
       #
       # @return [String] Hansi template representation of the pattern
@@ -70,10 +71,10 @@ module Mustermann
 
       # @example
       #   require 'mustermann/visualizer'
-      #   
+      #
       #   pattern   = Mustermann.new('/:name')
       #   highlight = Mustermann::Visualizer.highlight(pattern)
-      #   
+      #
       #   puts highlight.to_ansi
       #
       # @return [String] ANSI colorized version of the pattern
@@ -83,10 +84,10 @@ module Mustermann
 
       # @example
       #   require 'mustermann/visualizer'
-      #   
+      #
       #   pattern   = Mustermann.new('/:name')
       #   highlight = Mustermann::Visualizer.highlight(pattern)
-      #   
+      #
       #   puts highlight.to_html
       #
       # @return [String] HTML rendering of the pattern
@@ -96,10 +97,10 @@ module Mustermann
 
       # @example
       #   require 'mustermann/visualizer'
-      #   
+      #
       #   pattern   = Mustermann.new('/:name')
       #   highlight = Mustermann::Visualizer.highlight(pattern)
-      #   
+      #
       #   puts highlight.to_sexp
       #
       # @return [String] s-expression like representation of the pattern

--- a/mustermann-contrib/lib/mustermann/visualizer/highlighter.rb
+++ b/mustermann-contrib/lib/mustermann/visualizer/highlighter.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/visualizer/highlighter/ast'
 require 'mustermann/visualizer/highlighter/ad_hoc'
 require 'mustermann/visualizer/highlighter/composite'

--- a/mustermann-contrib/lib/mustermann/visualizer/highlighter/ad_hoc.rb
+++ b/mustermann-contrib/lib/mustermann/visualizer/highlighter/ad_hoc.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'strscan'
 
 module Mustermann
@@ -33,7 +34,7 @@ module Mustermann
         def initialize(pattern, renderer)
           @pattern  = pattern
           @renderer = renderer
-          @output   = ""
+          @output   = String.new
           @rules    = self.class.rules
           @scanner  = ::StringScanner.new(pattern.to_s)
         end

--- a/mustermann-contrib/lib/mustermann/visualizer/highlighter/ast.rb
+++ b/mustermann-contrib/lib/mustermann/visualizer/highlighter/ast.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/ast/translator'
 
 module Mustermann

--- a/mustermann-contrib/lib/mustermann/visualizer/highlighter/composite.rb
+++ b/mustermann-contrib/lib/mustermann/visualizer/highlighter/composite.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mustermann
   module Visualizer
     # @!visibility private

--- a/mustermann-contrib/lib/mustermann/visualizer/highlighter/dummy.rb
+++ b/mustermann-contrib/lib/mustermann/visualizer/highlighter/dummy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mustermann
   module Visualizer
     # @!visibility private
@@ -7,7 +8,7 @@ module Mustermann
       module Dummy
         # @!visibility private
         def self.highlight(pattern, renderer)
-          output = ""
+          output = String.new
           output << renderer.pre(:root) << renderer.pre(:unknown)
           output << renderer.escape(pattern.to_s)
           output << renderer.post(:unknown) << renderer.post(:root)

--- a/mustermann-contrib/lib/mustermann/visualizer/highlighter/regular.rb
+++ b/mustermann-contrib/lib/mustermann/visualizer/highlighter/regular.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'strscan'
 
 module Mustermann
@@ -27,7 +28,7 @@ module Mustermann
         # @!visibility private
         def initialize(renderer)
           @renderer = renderer
-          @output   = ""
+          @output   = String.new
         end
 
         # @!visibility private

--- a/mustermann-contrib/lib/mustermann/visualizer/pattern_extension.rb
+++ b/mustermann-contrib/lib/mustermann/visualizer/pattern_extension.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mustermann
   module Visualizer
     # Mixin that will be added to {Mustermann::Pattern}.

--- a/mustermann-contrib/lib/mustermann/visualizer/renderer/ansi.rb
+++ b/mustermann-contrib/lib/mustermann/visualizer/renderer/ansi.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mustermann
   module Visualizer
     # @!visibility private

--- a/mustermann-contrib/lib/mustermann/visualizer/renderer/generic.rb
+++ b/mustermann-contrib/lib/mustermann/visualizer/renderer/generic.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mustermann
   module Visualizer
     # @!visibility private

--- a/mustermann-contrib/lib/mustermann/visualizer/renderer/hansi_template.rb
+++ b/mustermann-contrib/lib/mustermann/visualizer/renderer/hansi_template.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/visualizer/renderer/generic'
 
 module Mustermann

--- a/mustermann-contrib/lib/mustermann/visualizer/renderer/html.rb
+++ b/mustermann-contrib/lib/mustermann/visualizer/renderer/html.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/visualizer/renderer/generic'
 require 'cgi'
 

--- a/mustermann-contrib/lib/mustermann/visualizer/renderer/sexp.rb
+++ b/mustermann-contrib/lib/mustermann/visualizer/renderer/sexp.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/visualizer/renderer/generic'
 
 module Mustermann

--- a/mustermann-contrib/lib/mustermann/visualizer/tree.rb
+++ b/mustermann-contrib/lib/mustermann/visualizer/tree.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'hansi'
 
 module Mustermann

--- a/mustermann-contrib/lib/mustermann/visualizer/tree_renderer.rb
+++ b/mustermann-contrib/lib/mustermann/visualizer/tree_renderer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/visualizer/tree'
 require 'mustermann/ast/translator'
 require 'hansi'

--- a/mustermann-contrib/spec/cake_spec.rb
+++ b/mustermann-contrib/spec/cake_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/cake'
 

--- a/mustermann-contrib/spec/express_spec.rb
+++ b/mustermann-contrib/spec/express_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/express'
 

--- a/mustermann-contrib/spec/file_utils_spec.rb
+++ b/mustermann-contrib/spec/file_utils_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/file_utils'
 

--- a/mustermann-contrib/spec/flask_spec.rb
+++ b/mustermann-contrib/spec/flask_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/flask'
 

--- a/mustermann-contrib/spec/flask_subclass_spec.rb
+++ b/mustermann-contrib/spec/flask_subclass_spec.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/flask'
 
 FlaskSubclass ||= Class.new(Mustermann::Flask)
-FlaskSubclass.register_converter(:foo) {} 
+FlaskSubclass.register_converter(:foo) {}
 
 describe FlaskSubclass do
   extend Support::Pattern

--- a/mustermann-contrib/spec/pattern_extension_spec.rb
+++ b/mustermann-contrib/spec/pattern_extension_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/visualizer'
 require 'pp'

--- a/mustermann-contrib/spec/pyramid_spec.rb
+++ b/mustermann-contrib/spec/pyramid_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/pyramid'
 

--- a/mustermann-contrib/spec/rails_spec.rb
+++ b/mustermann-contrib/spec/rails_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/rails'
 

--- a/mustermann-contrib/spec/shell_spec.rb
+++ b/mustermann-contrib/spec/shell_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/shell'
 

--- a/mustermann-contrib/spec/simple_spec.rb
+++ b/mustermann-contrib/spec/simple_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/simple'
 require 'mustermann/visualizer'

--- a/mustermann-contrib/spec/string_scanner_spec.rb
+++ b/mustermann-contrib/spec/string_scanner_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/string_scanner'
 

--- a/mustermann-contrib/spec/template_spec.rb
+++ b/mustermann-contrib/spec/template_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/template'
 

--- a/mustermann/lib/mustermann.rb
+++ b/mustermann/lib/mustermann.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/pattern'
 require 'mustermann/composite'
 require 'mustermann/concat'

--- a/mustermann/lib/mustermann/ast/boundaries.rb
+++ b/mustermann/lib/mustermann/ast/boundaries.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/ast/translator'
 
 module Mustermann

--- a/mustermann/lib/mustermann/ast/compiler.rb
+++ b/mustermann/lib/mustermann/ast/compiler.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/ast/translator'
 
 module Mustermann

--- a/mustermann/lib/mustermann/ast/expander.rb
+++ b/mustermann/lib/mustermann/ast/expander.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/ast/translator'
 require 'mustermann/ast/compiler'
 

--- a/mustermann/lib/mustermann/ast/param_scanner.rb
+++ b/mustermann/lib/mustermann/ast/param_scanner.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/ast/translator'
 
 module Mustermann

--- a/mustermann/lib/mustermann/ast/parser.rb
+++ b/mustermann/lib/mustermann/ast/parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/ast/node'
 require 'forwardable'
 require 'strscan'
@@ -150,7 +151,7 @@ module Mustermann
       #
       # @!visibility private
       def read_brackets(open, close, char: nil, escape: ?\\, quote: false, **options)
-        result = ""
+        result = String.new
         escape = false if escape.nil?
         while current = getch
           case current
@@ -193,7 +194,7 @@ module Mustermann
           case current
           when *close    then return result
           when ignore    then nil # do nothing
-          when separator then result  << ""
+          when separator then result  << String.new
           when escape    then element << getch
           when *quotes   then element << read_escaped(current, escape: escape)
           else element << current
@@ -206,7 +207,7 @@ module Mustermann
       #
       # @!visibility private
       def read_escaped(close, escape: ?\\, **options)
-        result = ""
+        result = String.new
         while current = getch
           case current
           when close  then return result

--- a/mustermann/lib/mustermann/ast/pattern.rb
+++ b/mustermann/lib/mustermann/ast/pattern.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/ast/parser'
 require 'mustermann/ast/boundaries'
 require 'mustermann/ast/compiler'
@@ -79,8 +80,7 @@ module Mustermann
         options[:except] &&= parse options[:except]
         compiler.compile(to_ast, **options)
       rescue CompileError => error
-        error.message << ": %p" % @string
-        raise error
+        raise error.class, "#{error.message}: #{@string.inspect}", error.backtrace
       end
 
       # Internal AST representation of pattern.

--- a/mustermann/lib/mustermann/ast/template_generator.rb
+++ b/mustermann/lib/mustermann/ast/template_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/ast/translator'
 
 module Mustermann

--- a/mustermann/lib/mustermann/ast/transformer.rb
+++ b/mustermann/lib/mustermann/ast/transformer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/ast/translator'
 
 module Mustermann

--- a/mustermann/lib/mustermann/ast/translator.rb
+++ b/mustermann/lib/mustermann/ast/translator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/ast/node'
 require 'mustermann/error'
 require 'delegate'
@@ -79,13 +80,13 @@ module Mustermann
       # @example
       #   require 'mustermann'
       #   require 'mustermann/ast/translator'
-      #   
+      #
       #   translator = Mustermann::AST::Translator.create do
       #     translate(:node)  { [type, *t(payload)].flatten.compact }
       #     translate(Array)  { map { |e| t(e) } }
       #     translate(Object) { }
       #   end
-      #   
+      #
       #   ast = Mustermann.new('/:name').to_ast
       #   translator.translate(ast) # => [:root, :separator, :capture]
       #

--- a/mustermann/lib/mustermann/ast/validation.rb
+++ b/mustermann/lib/mustermann/ast/validation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/ast/translator'
 
 module Mustermann

--- a/mustermann/lib/mustermann/caster.rb
+++ b/mustermann/lib/mustermann/caster.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'delegate'
 
 module Mustermann

--- a/mustermann/lib/mustermann/composite.rb
+++ b/mustermann/lib/mustermann/composite.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mustermann
   # Class for pattern objects composed of multiple patterns using binary logic.
   # @see Mustermann::Pattern#&

--- a/mustermann/lib/mustermann/concat.rb
+++ b/mustermann/lib/mustermann/concat.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mustermann
   # Class for pattern objects that are a concatenation of other patterns.
   # @see Mustermann::Pattern#+

--- a/mustermann/lib/mustermann/equality_map.rb
+++ b/mustermann/lib/mustermann/equality_map.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mustermann
   # A simple wrapper around ObjectSpace::WeakMap that allows matching keys by equality rather than identity.
   # Used for caching. Note that `fetch` is not guaranteed to return the object, even if it has not been
@@ -42,6 +43,7 @@ module Mustermann
     # @param [Object] object to be stored
     # @return [Object] same as the second parameter
     def track(key, object)
+      object = object.dup if object.frozen?
       ObjectSpace.define_finalizer(object, finalizer(key.hash))
       @keys[key.hash] = key
       object

--- a/mustermann/lib/mustermann/error.rb
+++ b/mustermann/lib/mustermann/error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mustermann
   Error        ||= Class.new(StandardError) # Raised if anything goes wrong while generating a {Pattern}.
   CompileError ||= Class.new(Error)         # Raised if anything goes wrong while compiling a {Pattern}.

--- a/mustermann/lib/mustermann/expander.rb
+++ b/mustermann/lib/mustermann/expander.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/ast/expander'
 require 'mustermann/caster'
 require 'mustermann'

--- a/mustermann/lib/mustermann/extension.rb
+++ b/mustermann/lib/mustermann/extension.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'sinatra/version'
 fail "no need to load the Mustermann extension for #{::Sinatra::VERSION}" if ::Sinatra::VERSION >= '2.0.0'
 

--- a/mustermann/lib/mustermann/identity.rb
+++ b/mustermann/lib/mustermann/identity.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann'
 require 'mustermann/pattern'
 require 'mustermann/ast/node'

--- a/mustermann/lib/mustermann/mapper.rb
+++ b/mustermann/lib/mustermann/mapper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann'
 require 'mustermann/expander'
 

--- a/mustermann/lib/mustermann/pattern.rb
+++ b/mustermann/lib/mustermann/pattern.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/error'
 require 'mustermann/simple_match'
 require 'mustermann/equality_map'

--- a/mustermann/lib/mustermann/pattern_cache.rb
+++ b/mustermann/lib/mustermann/pattern_cache.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'set'
 require 'thread'
 require 'mustermann'
@@ -8,7 +9,7 @@ module Mustermann
   # @example
   #   require 'mustermann/pattern_cache'
   #   cache = Mustermann::PatternCache.new
-  #   
+  #
   #   # use this instead of Mustermann.new
   #   pattern = cache.create_pattern("/:name", type: :rails)
   #

--- a/mustermann/lib/mustermann/regexp_based.rb
+++ b/mustermann/lib/mustermann/regexp_based.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann/pattern'
 require 'forwardable'
 

--- a/mustermann/lib/mustermann/regular.rb
+++ b/mustermann/lib/mustermann/regular.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann'
 require 'mustermann/regexp_based'
 require 'strscan'

--- a/mustermann/lib/mustermann/simple_match.rb
+++ b/mustermann/lib/mustermann/simple_match.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mustermann
   # Fakes MatchData for patterns that do not support capturing.
   # @see http://ruby-doc.org/core-2.0/MatchData.html MatchData

--- a/mustermann/lib/mustermann/sinatra.rb
+++ b/mustermann/lib/mustermann/sinatra.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann'
 require 'mustermann/identity'
 require 'mustermann/ast/pattern'

--- a/mustermann/lib/mustermann/sinatra/parser.rb
+++ b/mustermann/lib/mustermann/sinatra/parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mustermann
   class Sinatra < AST::Pattern
     # Sinatra syntax definition.

--- a/mustermann/lib/mustermann/sinatra/safe_renderer.rb
+++ b/mustermann/lib/mustermann/sinatra/safe_renderer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mustermann
   class Sinatra < AST::Pattern
     # Generates a string that can safely be concatenated with other strings

--- a/mustermann/lib/mustermann/sinatra/try_convert.rb
+++ b/mustermann/lib/mustermann/sinatra/try_convert.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mustermann
   class Sinatra < AST::Pattern
     # Tries to translate objects to Sinatra patterns.

--- a/mustermann/lib/mustermann/to_pattern.rb
+++ b/mustermann/lib/mustermann/to_pattern.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'mustermann'
 
 module Mustermann

--- a/mustermann/lib/mustermann/version.rb
+++ b/mustermann/lib/mustermann/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Mustermann
   VERSION ||= '1.0.0.beta2'
 end

--- a/mustermann/spec/ast_spec.rb
+++ b/mustermann/spec/ast_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/ast/node'
 

--- a/mustermann/spec/composite_spec.rb
+++ b/mustermann/spec/composite_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann'
 

--- a/mustermann/spec/concat_spec.rb
+++ b/mustermann/spec/concat_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann'
 

--- a/mustermann/spec/equality_map_spec.rb
+++ b/mustermann/spec/equality_map_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/equality_map'
 
@@ -16,9 +17,9 @@ RSpec.describe Mustermann::EqualityMap do
 
     specify 'with GC-removed entry' do
       next if subject.is_a? Hash
-      subject.fetch("foo") { "foo" }
+      subject.fetch(String.new('foo')) { "foo" }
       expect(subject.map).to receive(:[]).and_return(nil)
-      result = subject.fetch("foo") { "bar" }
+      result = subject.fetch(String.new('foo')) { "bar" }
       expect(result).to be == "bar"
     end
   end

--- a/mustermann/spec/expander_spec.rb
+++ b/mustermann/spec/expander_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/expander'
 

--- a/mustermann/spec/extension_spec.rb
+++ b/mustermann/spec/extension_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/extension'
 require 'sinatra/base'

--- a/mustermann/spec/identity_spec.rb
+++ b/mustermann/spec/identity_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/identity'
 

--- a/mustermann/spec/mapper_spec.rb
+++ b/mustermann/spec/mapper_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/mapper'
 

--- a/mustermann/spec/mustermann_spec.rb
+++ b/mustermann/spec/mustermann_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann'
 require 'mustermann/extension'

--- a/mustermann/spec/pattern_spec.rb
+++ b/mustermann/spec/pattern_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/pattern'
 require 'mustermann/sinatra'

--- a/mustermann/spec/regexp_based_spec.rb
+++ b/mustermann/spec/regexp_based_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/regexp_based'
 

--- a/mustermann/spec/regular_spec.rb
+++ b/mustermann/spec/regular_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/regular'
 

--- a/mustermann/spec/simple_match_spec.rb
+++ b/mustermann/spec/simple_match_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/simple_match'
 

--- a/mustermann/spec/sinatra_spec.rb
+++ b/mustermann/spec/sinatra_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/sinatra'
 

--- a/mustermann/spec/to_pattern_spec.rb
+++ b/mustermann/spec/to_pattern_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support'
 require 'mustermann/to_pattern'
 require 'delegate'


### PR DESCRIPTION
This enables frozen string literals across the board, both internally and when passed in from the outside.

With this patch, Mustermann can be used in Ruby application run with `--enable-frozen-string-literal` (assuming all other dependencies support this as well). Due to RSpec issues, it looks like we can't actually run specs with `--enable-frozen-string-literal` ourselves yet.

Note that frozen string literals will be enabled by default in Ruby 3.0.

The changes needed were minimal (mostly replacing string literals used as output buffer with `String.new`).