### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,23 @@
+language: ruby
+
+sudo: false
+
+cache: bundler
+
 before_install:
   - rvm get head
   - gem update bundler
 
 rvm:
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
+  - ruby-head
 
-script: bundle exec rspec **/spec/*_spec.rb
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true
 
 notifications:
   recipients:


### PR DESCRIPTION
Hello,

I want to update `.travis.yml`.

* Added "language: ruby" to show the languate mode explicitly.
* Added "sudo: false" and "cache: bundler" to save system resource.
* Updated to run default script (bundle exec rake) that includes
  both RSpec and Document status test.
  It looks more useful than current hard corded RSpec test.
* Updated Rubies to latest version.


And let me explain about that I added ruby-head as allow_failures.

I think this is useful.
Because we can support the next version Ruby as faster.

We can see this kind of logic in `rails`, `rspec` and `cucumber` and etc.
https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml

Could you merge this PR?
Thanks.
