### PR TITLE
Update summary and description in gemspec file.

### DIFF
--- a/mustermann/mustermann.gemspec
+++ b/mustermann/mustermann.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |s|
   s.authors               = ["Konstantin Haase", "Zachary Scott"]
   s.email                 = "sinatrarb@googlegroups.com"
   s.homepage              = "https://github.com/sinatra/mustermann"
-  s.summary               = %q{use patterns like regular expressions}
-  s.description           = %q{library implementing patterns that behave like regular expressions}
+  s.summary               = %q{Your personal string matching expert.}
+  s.description           = %q{A library implementing patterns that behave like regular expressions.}
   s.license               = 'MIT'
   s.required_ruby_version = '>= 2.2.0'
   s.files                 = `git ls-files`.split("\n")


### PR DESCRIPTION
I updated summary and description in gemspec file.
Because I thought that those looked not natural as English :)

I checked below use case after my modification.

```
$ gem build mustermann.gemspec
  Successfully built RubyGem
  Name: mustermann
  Version: 1.0.0
  File: mustermann-1.0.0.gem

$ gem specification mustermann-1.0.0.gem --ruby | grep -E '(summary|description)'
  s.description = "A library implementing patterns that behave like regular expressions.".freeze
  s.summary = "Your personal string matching expert.".freeze
```

How do you think?
Thank you.
