### PR TITLE
use Regexp#source instead of Regexp#inspect

### DIFF
--- a/mustermann/lib/mustermann/regular.rb
+++ b/mustermann/lib/mustermann/regular.rb
@@ -21,7 +21,7 @@ module Mustermann
     # @see (see Mustermann::Pattern#initialize)
     def initialize(string, check_anchors: true, **options)
       string = $1 if string.to_s =~ /\A\(\?\-mix\:(.*)\)\Z/ && string.inspect == "/#$1/"
-      string = string.inspect.gsub!(/(?<!\\)(?:\s|#.*(?:$|\/[mix]))/, '') if extended_regexp?(string)
+      string = string.source.gsub!(/(?<!\\)(?:\s|#.*$)/, '') if extended_regexp?(string)
       @check_anchors = check_anchors
       super(string, **options)
     end

--- a/mustermann/spec/regular_spec.rb
+++ b/mustermann/spec/regular_spec.rb
@@ -52,6 +52,7 @@ describe Mustermann::Regular do
       }x
     }
     example { expect { Timeout.timeout(1){ Mustermann::Regular.new(pattern) }}.not_to raise_error(Timeout::Error) }
+    it { expect(Mustermann::Regular.new(pattern)).to match('/compare/foo/bar..baz') }
   end
 
   describe :check_achnors do


### PR DESCRIPTION
To avoid regexp option suffixes, removed the inspect method.
Regexp#inspect has been implemented as human friendly feature, Regexp#source can be used instead.

@zzak @dometto Sorry for my bad, maybe this is correct. Could you confirm the operation?