### PR TITLE
look ahead same patterns as its own when concatenation

### DIFF
--- a/mustermann/spec/concat_spec.rb
+++ b/mustermann/spec/concat_spec.rb
@@ -57,6 +57,18 @@ describe Mustermann::Concat do
       its(:class) { should be == Mustermann::Concat }
       its(:to_s)  { should be == '(sinatra:"/:foo" + rails:"/:bar" + sinatra:"/:baz")' }
     end
+
+    context "sinatra + (sinatra + regular)" do
+      subject(:pattern) { Mustermann.new("/foo") + (Mustermann.new("/bar") + Mustermann.new(/baz/)) }
+      its(:class) { should be == Mustermann::Concat }
+      its(:to_s)  { should be == '(sinatra:"/foo/bar" + regular:"baz")' }
+    end
+
+    context "sinatra + (sinatra + rails (different options) + sinatra)" do
+      subject(:pattern) { Mustermann.new("/foo") + (Mustermann.new("/bar") + Mustermann.new("/baz", type: :rails, uri_decode: false) + Mustermann.new("/boo")) }
+      its(:class) { should be == Mustermann::Concat }
+      its(:to_s)  { should be == '(sinatra:"/foo/bar" + rails:"/baz" + sinatra:"/boo")' }
+    end
   end
 
   subject(:pattern) { Mustermann::Concat.new("/:foo", "/:bar") }


### PR DESCRIPTION
The meaning of the following two expressions is different, but it's unexpected behavior.

```ruby
Mustermann.new("/a") + Mustermann.new("/b") + Mustermann.new(/c/)
Mustermann.new("/a") + (Mustermann.new("/b") + Mustermann.new(/c/))
```

The differencet leads to occur a bug on sinatra-namespace.
This commit fixes https://github.com/sinatra/sinatra/issues/1361