### PR TITLE
gemspec: spelling in the description field

### DIFF
--- a/mustermann-contrib/mustermann-contrib.gemspec
+++ b/mustermann-contrib/mustermann-contrib.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.email                 = "sinatrarb@googlegroups.com"
   s.homepage              = "https://github.com/sinatra/mustermann"
   s.summary               = %q{Collection of extensions for Mustermann}
-  s.description           = %q{Adds many plugins to Mustermman}
+  s.description           = %q{Adds many plugins to Mustermann}
   s.license               = 'MIT'
   s.required_ruby_version = '>= 2.2.0'
   s.files                 = `git ls-files`.split("\n")


### PR DESCRIPTION
This PR fixes a spelling error of _Mustermann_ in the description.