### PR TITLE
[WIP] Add nested get query parameter expandation

### DIFF
--- a/mustermann/lib/mustermann/expander.rb
+++ b/mustermann/lib/mustermann/expander.rb
@@ -2,6 +2,7 @@
 require 'mustermann/ast/expander'
 require 'mustermann/caster'
 require 'mustermann'
+require 'addressable/uri'
 
 module Mustermann
   # Allows fine-grained control over pattern expansion.
@@ -194,7 +195,7 @@ module Mustermann
 
     def append(uri, values)
       return uri unless values and values.any?
-      [uri, QueryStringBuilder.new(values).build].join('?')
+      Addressable::URI.encode([uri, QueryStringBuilder.new(values).build].join('?'))
     end
 
     def map_values(values)

--- a/mustermann/lib/mustermann/expander.rb
+++ b/mustermann/lib/mustermann/expander.rb
@@ -195,7 +195,9 @@ module Mustermann
 
     def append(uri, values)
       return uri unless values and values.any?
-      Addressable::URI.encode([uri, QueryStringBuilder.new(values).build].join('?'))
+      Addressable::URI.encode(
+        [uri, uri.include?('?') ? '&' : '?', QueryStringBuilder.new(values).build].join
+      )
     end
 
     def map_values(values)

--- a/mustermann/spec/expander_spec.rb
+++ b/mustermann/spec/expander_spec.rb
@@ -70,6 +70,9 @@ describe Mustermann::Expander do
       subject(:expander) { Mustermann::Expander.new('/:a', additional_values: :append) }
       example { expander.expand(a: ?a).should be == '/a' }
       example { expander.expand(a: ?a, b: ?b).should be == '/a?b=b' }
+      example { expander.expand(a: ?a, b: [?b]).should be == '/a?b[]=b' }
+      example { expander.expand(a: ?a, b: {c: ?c}).should be == '/a?b[c]=c' }
+      example { expander.expand(a: ?a, b: {c: [1, 2]}).should be == '/a?b[c][]=1&b[c][]=2' }
       example { expect { expander.expand(b: ?b) }.to raise_error(Mustermann::ExpandError) }
     end
   end

--- a/mustermann/spec/expander_spec.rb
+++ b/mustermann/spec/expander_spec.rb
@@ -70,9 +70,9 @@ describe Mustermann::Expander do
       subject(:expander) { Mustermann::Expander.new('/:a', additional_values: :append) }
       example { expander.expand(a: ?a).should be == '/a' }
       example { expander.expand(a: ?a, b: ?b).should be == '/a?b=b' }
-      example { expander.expand(a: ?a, b: [?b]).should be == '/a?b[]=b' }
-      example { expander.expand(a: ?a, b: {c: ?c}).should be == '/a?b[c]=c' }
-      example { expander.expand(a: ?a, b: {c: [1, 2]}).should be == '/a?b[c][]=1&b[c][]=2' }
+      example { expander.expand(a: ?a, b: [?b]).should be == '/a?b%5B%5D=b' }
+      example { expander.expand(a: ?a, b: {c: ?c}).should be == '/a?b%5Bc%5D=c' }
+      example { expander.expand(a: ?a, b: {c: [1, 2]}).should be == '/a?b%5Bc%5D%5B%5D=1&b%5Bc%5D%5B%5D=2' }
       example { expect { expander.expand(b: ?b) }.to raise_error(Mustermann::ExpandError) }
     end
   end


### PR DESCRIPTION
I'm creating this issue https://github.com/sinatra/mustermann/issues/61 examples in this pull request!
What do you think about this approach?

```rb
pattern = Mustermann.new("/books/:id")
pattern.expand(:append, id: 5, include: ["foo"]) # => "/books/5?include[]=foo"
pattern.expand(:append, id: 5, foo: {bar: :baz}) # => "/books/5?foo[bar]=baz"
pattern.expand(:append, id: 5, foo: {bar: [1, 2]}) # => "/books/5?foo[bar][]=1&foo[bar][]=2"

```