### PR TITLE
Remove warning message on tests

### DIFF
--- a/mustermann/spec/regular_spec.rb
+++ b/mustermann/spec/regular_spec.rb
@@ -51,7 +51,7 @@ describe Mustermann::Regular do
         (.+)      # match the second SHA1
       }x
     }
-    example { expect { Timeout.timeout(1){ Mustermann::Regular.new(pattern) }}.not_to raise_error(Timeout::Error) }
+    example { expect { Timeout.timeout(1){ Mustermann::Regular.new(pattern) }}.not_to raise_error }
     it { expect(Mustermann::Regular.new(pattern)).to match('/compare/foo/bar..baz') }
   end
 


### PR DESCRIPTION
I removed this warning messages when I run tests

```
WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks
false positives, since literally any other error would cause the
expectation to pass, including those raised by Ruby (e.g. NoMethodError,
NameError and ArgumentError), meaning the code you are intending to test
may not even get reached. Instead consider using `expect { }.not_to
raise_error` or `expect { }.to
raise_error(DifferentSpecificErrorClass)`. This message can be
suppressed by setting:
`RSpec::Expectations.configuration.on_potential_false_positives =
:nothing`.
```