### PR TITLE
don't use adjusted values for reporting error

### DIFF
--- a/mustermann/lib/mustermann/ast/expander.rb
+++ b/mustermann/lib/mustermann/ast/expander.rb
@@ -92,11 +92,11 @@ module Mustermann
       # @see Mustermann::Pattern#expand
       # @!visibility private
       def expand(values)
-        values = values.each_with_object({}){ |(key, value), new_hash|
+        adjusted = values.each_with_object({}){ |(key, value), new_hash|
           new_hash[value.instance_of?(Array) ? [key] * value.length : key] = value }
-        keys, pattern, filters = mappings.fetch(values.keys.flatten.sort) { error_for(values) }
-        filters.each { |key, filter| values[key] &&= escape(values[key], also_escape: filter) }
-        pattern % (values[keys] || values.values_at(*keys))
+        keys, pattern, filters = mappings.fetch(adjusted.keys.flatten.sort) { error_for(values) }
+        filters.each { |key, filter| adjusted[key] &&= escape(adjusted[key], also_escape: filter) }
+        pattern % (adjusted[keys] || adjusted.values_at(*keys))
       end
 
       # @see Mustermann::Pattern#expandable?

--- a/mustermann/spec/expander_spec.rb
+++ b/mustermann/spec/expander_spec.rb
@@ -64,6 +64,8 @@ describe Mustermann::Expander do
       example { expander.expand(a: ?a).should be == '/a' }
       example { expander.expand(a: ?a, b: ?b).should be == '/a' }
       example { expect { expander.expand(b: ?b) }.to raise_error(Mustermann::ExpandError) }
+      example { expect { expander.expand(b: ?b, c: []) }.to raise_error(Mustermann::ExpandError) }
+      example { expect { expander.expand(b: ?b, c: [], d: ?d) }.to raise_error(Mustermann::ExpandError) }
     end
 
     context :append do


### PR DESCRIPTION
The previous code led regular error to be hidden and return meaningless ArgumentError.
In order to avoid that, this commit makes code not use adjusted values for
reporting error, use original values instead.

Fixes #88

@gerwitz Could you confirm that your issue has been fixed by this patch?
