### PR TITLE
Support Ruby 3 keyword arguments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 require File.expand_path('../support/lib/support/projects', __FILE__)
 
+gem 'ruby2_keywords'
 path '.' do
   Support::Projects.each { |name| gem(name) }
   gem 'support', group: :development

--- a/mustermann-contrib/lib/mustermann/visualizer/highlight.rb
+++ b/mustermann-contrib/lib/mustermann/visualizer/highlight.rb
@@ -16,7 +16,7 @@ module Mustermann
       attr_reader :pattern, :theme
 
       # @!visibility private
-      DEFAULT_THEME = Hansi::Theme.new(:solarized, {
+      DEFAULT_THEME = Hansi::Theme.new(:solarized,
         default:   :base0,
         separator: :base1,
         escaped:   :base1,
@@ -25,10 +25,10 @@ module Mustermann
         special:   :blue,
         quote:     :red,
         illegal:   :darkred
-      })
+      )
 
       # @!visibility private
-      BASE_THEME = Hansi::Theme.new({
+      BASE_THEME = Hansi::Theme.new(
         special:     :default,
         capture:     :special,
         char:        :default,
@@ -46,13 +46,13 @@ module Mustermann
         quote:       :special,
         type:        :special,
         illegal:     :special
-      })
+      )
 
       # @!visibility private
       def initialize(pattern, type: nil, inspect: nil, **theme)
         @pattern = Mustermann.new(pattern, type: type)
         @inspect = inspect.nil? ? pattern.is_a?(Mustermann::Composite) : inspect
-        theme    = theme.any? ? Hansi::Theme.new(theme) : DEFAULT_THEME
+        theme    = theme.any? ? Hansi::Theme.new(**theme) : DEFAULT_THEME
         @theme   = BASE_THEME.merge(theme)
       end
 

--- a/mustermann-contrib/lib/mustermann/visualizer/pattern_extension.rb
+++ b/mustermann-contrib/lib/mustermann/visualizer/pattern_extension.rb
@@ -53,7 +53,7 @@ module Mustermann
       def color_inspect(base_color = nil, **theme)
         base_color ||= Highlight::DEFAULT_THEME[:base01]
         template = is_a?(Composite) ? "*#<%p:(*%s*)>*" : "*#<%p:*%s*>*"
-        Hansi.render(template, self.class, to_ansi(inspect: true, **theme), "*" => base_color)
+        Hansi.render(template, self.class, to_ansi(inspect: true, **theme), {"*" => base_color})
       end
 
       # If invoked directly by IRB, same as {#color_inspect}, otherwise same as Object#pretty_print.

--- a/mustermann-contrib/lib/mustermann/visualizer/renderer/hansi_template.rb
+++ b/mustermann-contrib/lib/mustermann/visualizer/renderer/hansi_template.rb
@@ -10,7 +10,7 @@ module Mustermann
       # @!visibility private
       class HansiTemplate < Generic
         # @!visibility private
-        def initialize(*)
+        def initialize(*, **)
           @hansi = Hansi::StringRenderer.new(tags: true)
           super
         end

--- a/mustermann-contrib/spec/file_utils_spec.rb
+++ b/mustermann-contrib/spec/file_utils_spec.rb
@@ -53,7 +53,7 @@ describe Mustermann::FileUtils do
 
   describe :glob_map do
     example do
-      utils.glob_map(':name.rb' => ':name/init.rb').should be == {
+      utils.glob_map({':name.rb' => ':name/init.rb'}).should be == {
         "bar.rb" => "bar/init.rb",
         "foo.rb" => "foo/init.rb"
       }
@@ -61,7 +61,7 @@ describe Mustermann::FileUtils do
 
     example do
       result   = {}
-      returned = utils.glob_map(':name.rb' => ':name/init.rb') { |k, v| result[v] = k.upcase }
+      returned = utils.glob_map({':name.rb' => ':name/init.rb'}) { |k, v| result[v] = k.upcase }
       returned.sort         .should be == ["BAR.RB", "FOO.RB"]
       result["bar/init.rb"] .should be == "BAR.RB"
     end
@@ -69,7 +69,7 @@ describe Mustermann::FileUtils do
 
   describe :cp do
     example do
-      utils.cp(':name.rb' => ':name.ruby', ':name.txt' => ':name.md')
+      utils.cp({':name.rb' => ':name.ruby', ':name.txt' => ':name.md'})
       File.should be_exist('foo.ruby')
       File.should be_exist('bar.md')
       File.should be_exist('bar.txt')
@@ -79,14 +79,14 @@ describe Mustermann::FileUtils do
   describe :cp_r do
     example do
       mkdir_p "foo/bar"
-      utils.cp_r('foo/:name' => :name)
+      utils.cp_r({'foo/:name' => :name})
       File.should be_directory('bar')
     end
   end
 
   describe :mv do
     example do
-      utils.mv(':name.rb' => ':name.ruby', ':name.txt' => ':name.md')
+      utils.mv({':name.rb' => ':name.ruby', ':name.txt' => ':name.md'})
       File.should     be_exist('foo.ruby')
       File.should     be_exist('bar.md')
       File.should_not be_exist('bar.txt')
@@ -95,7 +95,7 @@ describe Mustermann::FileUtils do
 
   describe :ln do
     example do
-      utils.ln(':name.rb' => ':name.ruby', ':name.txt' => ':name.md')
+      utils.ln({':name.rb' => ':name.ruby', ':name.txt' => ':name.md'})
       File.should be_exist('foo.ruby')
       File.should be_exist('bar.md')
       File.should be_exist('bar.txt')
@@ -104,7 +104,7 @@ describe Mustermann::FileUtils do
 
   describe :ln_s do
     example do
-      utils.ln_s(':name.rb' => ':name.ruby', ':name.txt' => ':name.md')
+      utils.ln_s({':name.rb' => ':name.ruby', ':name.txt' => ':name.md'})
       File.should be_symlink('foo.ruby')
       File.should be_symlink('bar.md')
       File.should be_exist('bar.txt')
@@ -113,7 +113,7 @@ describe Mustermann::FileUtils do
 
   describe :ln_sf do
     example do
-      utils.ln_sf(':name.rb' => ':name.txt')
+      utils.ln_sf({':name.rb' => ':name.txt'})
       File.should be_symlink('foo.txt')
     end
   end

--- a/mustermann/lib/mustermann.rb
+++ b/mustermann/lib/mustermann.rb
@@ -3,6 +3,7 @@ require 'mustermann/pattern'
 require 'mustermann/composite'
 require 'mustermann/concat'
 require 'thread'
+require 'ruby2_keywords'
 
 # Namespace and main entry point for the Mustermann library.
 #

--- a/mustermann/lib/mustermann/ast/compiler.rb
+++ b/mustermann/lib/mustermann/ast/compiler.rb
@@ -40,7 +40,7 @@ module Mustermann
 
         # @!visibility private
         def translate(**options)
-          return pattern(options) if options[:no_captures]
+          return pattern(**options) if options[:no_captures]
           "(?<#{name}>#{translate(no_captures: true, **options)})"
         end
 

--- a/mustermann/lib/mustermann/ast/expander.rb
+++ b/mustermann/lib/mustermann/ast/expander.rb
@@ -137,7 +137,7 @@ module Mustermann
       # @!visibility private
       def add_to(list, result)
         list << [[], ""] if list.empty?
-        list.inject([]) { |l, (k1, p1, f1)| l + result.map { |k2, p2, f2| [k1+k2, p1+p2, **f1, **f2] } }
+        list.inject([]) { |l, (k1, p1, f1)| l + result.map { |k2, p2, f2| [k1+k2, p1+p2, f1.merge(f2)] } }
       end
     end
   end

--- a/mustermann/lib/mustermann/ast/expander.rb
+++ b/mustermann/lib/mustermann/ast/expander.rb
@@ -122,7 +122,7 @@ module Mustermann
 
       # @see Mustermann::AST::Translator#expand
       # @!visibility private
-      def escape(string, *args)
+      ruby2_keywords def escape(string, *args)
         # URI::Parser is pretty slow, let's not send every string to it, even if it's unnecessary
         string =~ /\A\w*\Z/ ? string : super
       end

--- a/mustermann/lib/mustermann/ast/parser.rb
+++ b/mustermann/lib/mustermann/ast/parser.rb
@@ -64,7 +64,7 @@ module Mustermann
       # @param [Symbol] type node type
       # @return [Mustermann::AST::Node]
       # @!visibility private
-      def node(type, *args, &block)
+      ruby2_keywords def node(type, *args, &block)
         type  = Node[type] unless type.respond_to? :new
         start = pos
         node  = block ? type.parse(*args, &block) : type.new(*args)

--- a/mustermann/lib/mustermann/ast/translator.rb
+++ b/mustermann/lib/mustermann/ast/translator.rb
@@ -36,7 +36,7 @@ module Mustermann
 
         # shorthand for translating a nested object
         # @!visibility private
-        def t(*args, &block)
+        ruby2_keywords def t(*args, &block)
           return translator unless args.any?
           translator.translate(*args, &block)
         end
@@ -109,7 +109,7 @@ module Mustermann
 
       # Start the translation dance for a (sub)tree.
       # @!visibility private
-      def translate(node, *args, &block)
+      ruby2_keywords def translate(node, *args, &block)
         result = decorator_for(node).translate(*args, &block)
         result = result.node while result.is_a? NodeTranslator
         result

--- a/mustermann/lib/mustermann/composite.rb
+++ b/mustermann/lib/mustermann/composite.rb
@@ -102,9 +102,9 @@ module Mustermann
     end
 
     # @!visibility private
-    def patterns_from(pattern, options = nil)
+    def patterns_from(pattern, **options)
       return pattern.patterns if pattern.is_a? Composite and pattern.operator == self.operator
-      [options ? Mustermann.new(pattern, **options) : pattern]
+      [options.empty? && pattern.is_a?(Pattern) ? pattern : Mustermann.new(pattern, **options)]
     end
 
     private :with_matching, :patterns_from

--- a/mustermann/lib/mustermann/concat.rb
+++ b/mustermann/lib/mustermann/concat.rb
@@ -40,7 +40,7 @@ module Mustermann
 
     # Should not be used directly.
     # @!visibility private
-    def initialize(*)
+    def initialize(*, **)
       super
       AST::Validation.validate(combined_ast) if respond_to? :expand
     end

--- a/mustermann/lib/mustermann/pattern.rb
+++ b/mustermann/lib/mustermann/pattern.rb
@@ -56,7 +56,7 @@ module Mustermann
       end
 
       @map ||= EqualityMap.new
-      @map.fetch([string, options]) { super(string, options) { options } }
+      @map.fetch([string, options]) { super(string, **options) { options } }
     end
 
     supported_options :uri_decode, :ignore_unknown_options

--- a/mustermann/mustermann.gemspec
+++ b/mustermann/mustermann.gemspec
@@ -14,4 +14,6 @@ Gem::Specification.new do |s|
   s.files                 = `git ls-files`.split("\n")
   s.test_files            = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables           = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+
+  s.add_runtime_dependency('ruby2_keywords', '~> 0.0.1')
 end

--- a/mustermann/spec/mapper_spec.rb
+++ b/mustermann/spec/mapper_spec.rb
@@ -19,21 +19,14 @@ describe Mustermann::Mapper do
     end
 
     context 'accepts mappings followed by options' do
-      subject(:mapper) { Mustermann::Mapper.new("/foo" => "/bar", additional_values: :raise) }
-      its(:to_h) { should be == { Mustermann.new("/foo") => Mustermann::Expander.new("/bar") } }
-      example { mapper['/foo'].should be == '/bar' }
-      example { mapper['/fox'].should be == '/fox' }
-    end
-
-    context 'accepts options followed by mappings' do
-      subject(:mapper) { Mustermann::Mapper.new(additional_values: :raise, "/foo" => "/bar") }
+      subject(:mapper) { Mustermann::Mapper.new({ "/foo" => "/bar" }, additional_values: :raise) }
       its(:to_h) { should be == { Mustermann.new("/foo") => Mustermann::Expander.new("/bar") } }
       example { mapper['/foo'].should be == '/bar' }
       example { mapper['/fox'].should be == '/fox' }
     end
 
     context 'allows specifying type' do
-      subject(:mapper) { Mustermann::Mapper.new(additional_values: :raise, type: :rails, "/foo" => "/bar") }
+      subject(:mapper) { Mustermann::Mapper.new({ "/foo" => "/bar" }, additional_values: :raise, type: :rails) }
       its(:to_h) { should be == { Mustermann.new("/foo", type: :rails) => Mustermann::Expander.new("/bar", type: :rails) } }
       example { mapper['/foo'].should be == '/bar' }
       example { mapper['/fox'].should be == '/fox' }

--- a/support/lib/support/pattern.rb
+++ b/support/lib/support/pattern.rb
@@ -9,7 +9,7 @@ module Support
 
       if options
         description << " with options %p" % [options]
-        instance = subject_for(pattern, options)
+        instance = subject_for(pattern, **options)
       else
         instance = subject_for(pattern)
       end
@@ -30,8 +30,8 @@ module Support
       end
     end
 
-    def subject_for(pattern, *args)
-      instance = Timeout.timeout(1) { described_class.new(pattern, *args) }
+    def subject_for(pattern, *args, **options)
+      instance = Timeout.timeout(1) { described_class.new(pattern, *args, **options) }
       proc { instance }
     rescue Timeout::Error => error
       proc { raise Timeout::Error, "could not compile #{pattern.inspect} in time", error.backtrace }


### PR DESCRIPTION
This PR allows rspec to pass in Ruby 2.7.

FYI: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/