### PR TITLE
Require ruby2_keywords when needed

### DIFF
--- a/mustermann/lib/mustermann.rb
+++ b/mustermann/lib/mustermann.rb
@@ -3,7 +3,6 @@ require 'mustermann/pattern'
 require 'mustermann/composite'
 require 'mustermann/concat'
 require 'thread'
-require 'ruby2_keywords'
 
 # Namespace and main entry point for the Mustermann library.
 #

--- a/mustermann/lib/mustermann/ast/expander.rb
+++ b/mustermann/lib/mustermann/ast/expander.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'mustermann/ast/translator'
 require 'mustermann/ast/compiler'
+require 'ruby2_keywords'
 
 module Mustermann
   module AST

--- a/mustermann/lib/mustermann/ast/parser.rb
+++ b/mustermann/lib/mustermann/ast/parser.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'mustermann/ast/node'
 require 'forwardable'
+require 'ruby2_keywords'
 require 'strscan'
 
 module Mustermann

--- a/mustermann/lib/mustermann/ast/translator.rb
+++ b/mustermann/lib/mustermann/ast/translator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'mustermann/ast/node'
 require 'mustermann/error'
+require 'ruby2_keywords'
 require 'delegate'
 
 module Mustermann


### PR DESCRIPTION
Instead of requiring ruby2_keywords in mustermann top library which may not be loaded by all classes, we could require ruby2_keywords in the several places (3 files) needing it.

Fix #102 