### PR TITLE
Avoid "deprecated Object#=~ is called on Integer"

### DIFF
--- a/mustermann/lib/mustermann/ast/translator.rb
+++ b/mustermann/lib/mustermann/ast/translator.rb
@@ -120,7 +120,7 @@ module Mustermann
       # @!visibility private
       def escape(char, parser: URI::DEFAULT_PARSER, escape: parser.regexp[:UNSAFE], also_escape: nil)
         escape = Regexp.union(also_escape, escape) if also_escape
-        char =~ escape ? parser.escape(char, Regexp.union(*escape)) : char
+        char.to_s =~ escape ? parser.escape(char, Regexp.union(*escape)) : char
       end
     end
   end


### PR DESCRIPTION
Convert to a string before attempting to match, so as to avoid a warning.

## Background

In a test suite I was using, I saw this warning printed liberally:

    warning: deprecated Object#=~ is called on Integer; it always returns nil

Change inspired by the same kind of fix here: https://github.com/rails/rails/commit/eafff15a023670974bd71efaec51e4c80364b95d

## Things I didn't do

- I didn't try to bail early, for speed, if the given `char` was not a String
- I didn't try to check the speed of this
- I didn't add a new test for this