### PR TITLE
Remove redcarpet dependency as it not being used

### DIFF
--- a/support/support.gemspec
+++ b/support/support.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'rack-test'
   s.add_dependency 'rake'
   s.add_dependency 'yard'
-  s.add_dependency 'redcarpet'
   s.add_dependency 'simplecov'
   s.add_dependency 'coveralls'
 end


### PR DESCRIPTION
Redcarpet seems to not be used at all, there isn't any test failing after its removal and is not referenced throughout the project.

Moreover this dependency blocks the installation of mustermann under jruby so I'm removing it.