### PR TITLE
CI: Add Ruby 3.1 to build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.6, 2.7, '3.0', head, jruby-head]
+        ruby: [2.6, 2.7, '3.0', 3.1, head, jruby-head]
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This PR adds Ruby 3.1 to the build matrix.

**Update**: Ha, I forgot that we didn't support 3.0, yet! https://github.com/sinatra/mustermann/issues/114 