### PR TITLE
Drop "executables" directive from mustermann

### DIFF
--- a/mustermann/mustermann.gemspec
+++ b/mustermann/mustermann.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.2.0'
   s.files                 = `git ls-files`.split("\n")
   s.test_files            = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables           = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 
   s.add_runtime_dependency('ruby2_keywords', '~> 0.0.1')
 end


### PR DESCRIPTION
This PR removes the unused "executables" directive from the `mustermann` gem.
