### PR TITLE
Use String.new instead of quotes #110

### DIFF
--- a/mustermann/lib/mustermann/ast/node.rb
+++ b/mustermann/lib/mustermann/ast/node.rb
@@ -108,7 +108,7 @@ module Mustermann
         # @see Mustermann::AST::Node#parse
         # @!visibility private
         def parse
-          self.payload ||= ""
+          self.payload ||= String.new
           super
         end
 


### PR DESCRIPTION
### Motivation
Mustermann is not compatible with --enable=frozen-string-literal. Running with such option raises Runtime error:  

```
FrozenError:
       can't modify frozen String: ""
```
### Issue

https://github.com/sinatra/mustermann/issues/110

### Changes

* Change double quotes (`""`) to `String.new` 

### Addition notes

Command I have used to run specs (in project root directory): 
```
RUBYOPT=--enable=frozen-string-literal bundle exec rspec
```

There are unfortunatelly 2 additional things I had to locally fix in the dependencies to make all the test passing:

1.  [Hansi::StringRendered#L38](https://github.com/rkh/hansi/blob/master/lib/hansi/string_renderer.rb#L38) is also working with frozen string literal. This is not an issue since this is dependencie of `mustermann-contrib` :) If it makes sense I can go there and make another PR. 
2. [Rack::MockRequest#L125](https://github.com/rack/rack/blob/1-6-stable/lib/rack/mock.rb#L125) is also working with string that is frozen. This has been changed in versions >= 2.0.0 to use `String.new`. So as soon as sinatra dependency is updated this wont be any problem. This is also not an issue since this is used only in tests. 

 
