### PR TITLE
Remove `--tty` option to show test results

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -2,4 +2,3 @@
 -r bundler/setup
 --default-path .
 --color
---tty


### PR DESCRIPTION
I found that the results of CI in GitHub Actions are not displayed.
https://github.com/sinatra/mustermann/runs/6508522098?check_suite_focus=true
![image](https://user-images.githubusercontent.com/32959831/169547456-34700d7c-cca2-4d4c-9577-de79fc150ba0.png)

This PR removes `--tty` option from `.rspec` to fix this issue.

The results of CI can be seen here: https://github.com/mishina2228/mustermann/runs/6526458871?check_suite_focus=true
![image](https://user-images.githubusercontent.com/32959831/169550136-3052352a-d59b-49b9-949c-e98cb5a131e7.png)
