### PR TITLE
Fix usage of ruby2_keywords, only use it for blocks which delegate

### DIFF
--- a/mustermann/lib/mustermann/ast/expander.rb
+++ b/mustermann/lib/mustermann/ast/expander.rb
@@ -12,11 +12,11 @@ module Mustermann
     class Expander < Translator
       raises ExpandError
 
-      translate Array do |*args|
+      translate(Array, &-> (*args) do
         inject(t.pattern) do |pattern, element|
           t.add_to(pattern, t(element, *args))
         end
-      end
+      end.ruby2_keywords)
 
       translate :capture do |**options|
         t.for_capture(node, **options)

--- a/mustermann/lib/mustermann/ast/translator.rb
+++ b/mustermann/lib/mustermann/ast/translator.rb
@@ -73,7 +73,6 @@ module Mustermann
         Class.new(const_get(:NodeTranslator)) do
           register(*types)
           define_method(:translate, &block)
-          ruby2_keywords :translate
         end
       end
 


### PR DESCRIPTION
Address the issue reported in #128.

`bundle exec rake` has no ruby2_keywords warnings with this.