### PR TITLE
Test against Ruby 3.2, fix broken things

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, truffleruby]
+        ruby: [2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, head, truffleruby]
         include:
           - { ruby: jruby-9.3, allow-failure: true }
     steps:

--- a/mustermann/lib/mustermann/ast/expander.rb
+++ b/mustermann/lib/mustermann/ast/expander.rb
@@ -124,6 +124,8 @@ module Mustermann
       # @see Mustermann::AST::Translator#expand
       # @!visibility private
       ruby2_keywords def escape(string, *args)
+        return super unless string.respond_to?(:=~)
+
         # URI::Parser is pretty slow, let's not send every string to it, even if it's unnecessary
         string =~ /\A\w*\Z/ ? string : super
       end

--- a/mustermann/lib/mustermann/ast/node.rb
+++ b/mustermann/lib/mustermann/ast/node.rb
@@ -35,8 +35,8 @@ module Mustermann
       # Helper for creating a new instance and calling #parse on it.
       # @return [Mustermann::AST::Node]
       # @!visibility private
-      def self.parse(*args, &block)
-        new(*args).tap { |n| n.parse(&block) }
+      def self.parse(payload = nil, **options, &block)
+        new(payload, **options).tap { |n| n.parse(&block) }
       end
 
       # @!visibility private


### PR DESCRIPTION
My build for a PR in `ruby-grape/grape-swagger`, which depends on `mustermann`, [failed on Ruby 3.2](https://github.com/ruby-grape/grape-swagger/runs/7422461584?check_suite_focus=true#step:4:9). Digging into the failure, it seems to be caused by a change concerning `ruby2_keywords`:

> Methods taking a rest parameter (like `*args`) and wishing to delegate keyword arguments through `foo(*args)` must now be marked with `ruby2_keywords` (if not already the case). In other words, all methods wishing to delegate keyword arguments through `*args` must now be marked with `ruby2_keywords`, with no exception. This will make it easier to transition to other ways of delegation once a library can require Ruby 3+. Previously, the `ruby2_keywords` flag was kept if the receiving method took `*args`, but this was a bug and an inconsistency. A good technique to find the potentially-missing `ruby2_keywords` is to run the test suite, for where it fails find the last method which must receive keyword arguments, use `puts nil, caller, nil` there, and check each method/block on the call chain which must delegate keywords is correctly marked as `ruby2_keywords`. [[Bug #18625](https://bugs.ruby-lang.org/issues/18625)] [[Bug #16466](https://bugs.ruby-lang.org/issues/16466)]
>
> ```ruby
> def target(**kw)
> end
>
> # Accidentally worked without ruby2_keywords in Ruby 2.7-3.1, ruby2_keywords
> # needed in 3.2+. Just like (*args, **kwargs) or (...) would be needed on
> # both #foo and #bar when migrating away from ruby2_keywords.
> ruby2_keywords def bar(*args)
>   target(*args)
> end
>
> ruby2_keywords def foo(*args)
>   bar(*args)
> end
>
> foo(k: 1)
> ```

There's probably other methods that now need to be marked? I added `head` to the CI test matrix, so those should be caught there.