### PR TITLE
Use URI::RFC2396_Parser#regex explicitly.

### DIFF
--- a/mustermann/lib/mustermann/ast/translator.rb
+++ b/mustermann/lib/mustermann/ast/translator.rb
@@ -118,7 +118,7 @@ module Mustermann
 
       # @return [String] escaped character
       # @!visibility private
-      def escape(char, parser: URI::DEFAULT_PARSER, escape: parser.regexp[:UNSAFE], also_escape: nil)
+      def escape(char, parser: URI::DEFAULT_PARSER, escape: URI::RFC2396_Parser.new.regexp[:UNSAFE], also_escape: nil)
         escape = Regexp.union(also_escape, escape) if also_escape
         char.to_s =~ escape ? parser.escape(char, Regexp.union(*escape)) : char
       end


### PR DESCRIPTION
I got the following error with the current develop version of `ruby/ruby`.

```
  87) Mustermann::Template level 4 operator + pattern "/{a}/{+b}" is expected to expand {:a=>"foo/bar", :b=>"foo/bar"}
      Failure/Error: it { should expand(a: 'foo/bar', b: 'foo/bar').to('/foo%2Fbar/foo/bar') }

      TypeError:
        no implicit conversion of nil into String
      # ./mustermann/lib/mustermann/ast/translator.rb:122:in 'Regexp.union'
```

In background, URI will change DEFAULT_PARSER to RFC3986_Parser.

https://github.com/ruby/uri/pull/107

After that, we lost some of regex pattern like UNSAFE.

