### PR TITLE
Use rfc2396 parser 

### DIFF
--- a/mustermann/lib/mustermann/ast/translator.rb
+++ b/mustermann/lib/mustermann/ast/translator.rb
@@ -118,7 +118,7 @@ module Mustermann
 
       # @return [String] escaped character
       # @!visibility private
-      def escape(char, parser: URI::RFC2396_PARSER, escape: URI::RFC2396_PARSER.regexp[:UNSAFE], also_escape: nil)
+      def escape(char, parser: URI::RFC2396_Parser.new, escape: URI::RFC2396_Parser.new.regexp[:UNSAFE], also_escape: nil)
         escape = Regexp.union(also_escape, escape) if also_escape
         char.to_s =~ escape ? parser.escape(char, Regexp.union(*escape)) : char
       end

--- a/mustermann/lib/mustermann/ast/translator.rb
+++ b/mustermann/lib/mustermann/ast/translator.rb
@@ -118,7 +118,7 @@ module Mustermann
 
       # @return [String] escaped character
       # @!visibility private
-      def escape(char, parser: URI::DEFAULT_PARSER, escape: URI::RFC2396_Parser.new.regexp[:UNSAFE], also_escape: nil)
+      def escape(char, parser: URI::RFC2396_PARSER, escape: URI::RFC2396_Parser.new.regexp[:UNSAFE], also_escape: nil)
         escape = Regexp.union(also_escape, escape) if also_escape
         char.to_s =~ escape ? parser.escape(char, Regexp.union(*escape)) : char
       end

--- a/mustermann/lib/mustermann/ast/translator.rb
+++ b/mustermann/lib/mustermann/ast/translator.rb
@@ -118,7 +118,7 @@ module Mustermann
 
       # @return [String] escaped character
       # @!visibility private
-      def escape(char, parser: URI::RFC2396_PARSER, escape: URI::RFC2396_Parser.new.regexp[:UNSAFE], also_escape: nil)
+      def escape(char, parser: URI::RFC2396_PARSER, escape: URI::RFC2396_PARSER.regexp[:UNSAFE], also_escape: nil)
         escape = Regexp.union(also_escape, escape) if also_escape
         char.to_s =~ escape ? parser.escape(char, Regexp.union(*escape)) : char
       end

--- a/mustermann/lib/mustermann/pattern.rb
+++ b/mustermann/lib/mustermann/pattern.rb
@@ -9,7 +9,7 @@ module Mustermann
   # @abstract
   class Pattern
     include Mustermann
-    @@uri ||= URI::Parser.new
+    @@uri ||= URI::RFC2396_Parser.new
 
     # List of supported options.
     #


### PR DESCRIPTION
Fixed up https://github.com/sinatra/mustermann/pull/138

`URI::DEFAULT_PARSER.escape` is obsoleted at next stable release of URI. We should use `URI::RFC2396_PARSER.escape` instead of `URI::DEFAULT_PARSER`.