### PR TITLE
Performance improvement for Mustermann::AST::Translator#escape

### DIFF
--- a/mustermann/bench/uri_parser_object.rb
+++ b/mustermann/bench/uri_parser_object.rb
@@ -1,0 +1,16 @@
+require "objspace"
+require "uri"
+require_relative "../lib/mustermann/ast/translator"
+
+translator = Mustermann::AST::Translator.new
+translator.escape("foo")
+
+h1 = ObjectSpace.each_object.inject(Hash.new 0) { |h, o| h[o.class] += 1; h }
+
+100.times do
+  translator.escape("foo")
+end
+
+h2 = ObjectSpace.each_object.inject(Hash.new 0) { |h, o| h[o.class] += 1; h }
+
+raise if (h2[URI::RFC2396_Parser] - h1[URI::RFC2396_Parser] != 0)

--- a/mustermann/lib/mustermann/ast/translator.rb
+++ b/mustermann/lib/mustermann/ast/translator.rb
@@ -116,9 +116,19 @@ module Mustermann
         result
       end
 
+      # @return [URI::RFC2396_Parser] URI::RFC2396 parser
+      # @!visibility private
+      def uri_parser
+        if defined?(URI::RFC2396_PARSER)
+          URI::RFC2396_PARSER
+        else
+          @uri_parser ||= URI::RFC2396_Parser.new
+        end
+      end
+
       # @return [String] escaped character
       # @!visibility private
-      def escape(char, parser: URI::RFC2396_Parser.new, escape: URI::RFC2396_Parser.new.regexp[:UNSAFE], also_escape: nil)
+      def escape(char, parser: uri_parser, escape: uri_parser.regexp[:UNSAFE], also_escape: nil)
         escape = Regexp.union(also_escape, escape) if also_escape
         char.to_s =~ escape ? parser.escape(char, Regexp.union(*escape)) : char
       end


### PR DESCRIPTION
Fix #140 

see `bench/uri_parser_object.rb`.

Before:

`h2[URI::RFC2396_Parser] - h1[URI::RFC2396_Parser]` is 200

After:

`h2[URI::RFC2396_Parser] - h1[URI::RFC2396_Parser]` is 0

