### PR TITLE
CI: Enable jruby-head, don't allow jruby releases to fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,8 @@ jobs:
           - { ruby: 2.6, sinatra: ~> 3.0.0 }
           - { ruby: 3.4, sinatra: head }
           - { ruby: head, sinatra: head }
-          # https://github.com/sinatra/mustermann/issues/72
-          - { ruby: jruby, sinatra: ~> 4.0.0, allow-failure: true }
+          - { ruby: jruby, sinatra: ~> 4.0.0 }
+          - { ruby: jruby-head, sinatra: head }
           # https://github.com/sinatra/mustermann/issues/143
           - { ruby: truffleruby, sinatra: ~> 4.0.0, allow-failure: true }
     env:


### PR DESCRIPTION
In jruby/jruby#8922 a bug was reported in JRuby 10.0.1.0 that might have been caught before release had mustermann's CI been running `jruby-head` builds without enabling `allow-failure`. This PR will modify mustermann CI to run both `jruby` and `jruby-head`, the latter against sinatra head, without allowing failures to be silently ignored (because we'll fix them).