### PR TITLE
Remove use of `ruby2_keywords`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,6 @@ jobs:
         sinatra:
           - ~> 4.0.0 # current stable
         include:
-          - { ruby: 2.6, sinatra: ~> 3.0.0 }
           - { ruby: 3.4, sinatra: head }
           - { ruby: head, sinatra: head }
           - { ruby: jruby, sinatra: ~> 4.0.0 }

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 require File.expand_path('../support/lib/support/projects', __FILE__)
 
-gem 'ruby2_keywords'
 path '.' do
   Support::Projects.each { |name| gem(name) }
   gem 'support', group: :development

--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,8 @@ task(:rspec)     { ruby '-S rspec'      }
 desc 'Run "yard stats"'
 task(:doc_stats) { ruby '-S yard stats' }
 
-task default: [:rspec, :doc_stats]
+# YARD is having issues on TruffleRuby, so we skip it there.
+task default: RUBY_ENGINE == "truffleruby" ? :rspec : [:rspec, :doc_stats]
 
 desc 'Build the gems'
 task :pkg do

--- a/mustermann-contrib/mustermann-contrib.gemspec
+++ b/mustermann-contrib/mustermann-contrib.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.summary               = %q{Collection of extensions for Mustermann}
   s.description           = %q{Adds many plugins to Mustermann}
   s.license               = 'MIT'
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 2.7.0'
   s.files                 = `git ls-files`.split("\n")
   s.test_files            = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.add_dependency 'mustermann', Mustermann::VERSION

--- a/mustermann/lib/mustermann/ast/expander.rb
+++ b/mustermann/lib/mustermann/ast/expander.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'mustermann/ast/translator'
 require 'mustermann/ast/compiler'
-require 'ruby2_keywords'
 
 module Mustermann
   module AST
@@ -12,11 +11,11 @@ module Mustermann
     class Expander < Translator
       raises ExpandError
 
-      translate(Array, &-> (*args) do
+      translate Array do |*args, **options|
         inject(t.pattern) do |pattern, element|
-          t.add_to(pattern, t(element, *args))
+          t.add_to(pattern, t(element, *args, **options))
         end
-      end.ruby2_keywords)
+      end
 
       translate :capture do |**options|
         t.for_capture(node, **options)
@@ -123,7 +122,7 @@ module Mustermann
 
       # @see Mustermann::AST::Translator#expand
       # @!visibility private
-      ruby2_keywords def escape(string, *args)
+      def escape(string, *args, **options)
         return super unless string.respond_to?(:=~)
 
         # URI::Parser is pretty slow, let's not send every string to it, even if it's unnecessary

--- a/mustermann/lib/mustermann/ast/parser.rb
+++ b/mustermann/lib/mustermann/ast/parser.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'mustermann/ast/node'
 require 'forwardable'
-require 'ruby2_keywords'
 require 'strscan'
 
 module Mustermann
@@ -65,10 +64,10 @@ module Mustermann
       # @param [Symbol] type node type
       # @return [Mustermann::AST::Node]
       # @!visibility private
-      ruby2_keywords def node(type, *args, &block)
+      def node(type, *args, **options, &block)
         type  = Node[type] unless type.respond_to? :new
         start = pos
-        node  = block ? type.parse(*args, &block) : type.new(*args)
+        node  = block ? type.parse(*args, **options, &block) : type.new(*args, **options)
         min_size(start, pos, node)
       end
 

--- a/mustermann/lib/mustermann/ast/translator.rb
+++ b/mustermann/lib/mustermann/ast/translator.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'mustermann/ast/node'
 require 'mustermann/error'
-require 'ruby2_keywords'
 require 'delegate'
 
 module Mustermann
@@ -40,9 +39,9 @@ module Mustermann
 
         # shorthand for translating a nested object
         # @!visibility private
-        ruby2_keywords def t(*args, &block)
+        def t(*args, **options, &block)
           return translator unless args.any?
-          translator.translate(*args, &block)
+          translator.translate(*args, **options, &block)
         end
 
         # @!visibility private
@@ -113,8 +112,8 @@ module Mustermann
 
       # Start the translation dance for a (sub)tree.
       # @!visibility private
-      ruby2_keywords def translate(node, *args, &block)
-        result = decorator_for(node).translate(*args, &block)
+      def translate(node, *args, **options, &block)
+        result = decorator_for(node).translate(*args, **options, &block)
         result = result.node while result.is_a? NodeTranslator
         result
       end

--- a/mustermann/mustermann.gemspec
+++ b/mustermann/mustermann.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.summary               = %q{Your personal string matching expert.}
   s.description           = %q{A library implementing patterns that behave like regular expressions.}
   s.license               = 'MIT'
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 2.7.0'
   s.files                 = `git ls-files`.split("\n")
   s.test_files            = `git ls-files -- {test,spec,features}/*`.split("\n")
 end

--- a/mustermann/mustermann.gemspec
+++ b/mustermann/mustermann.gemspec
@@ -13,6 +13,4 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.6.0'
   s.files                 = `git ls-files`.split("\n")
   s.test_files            = `git ls-files -- {test,spec,features}/*`.split("\n")
-
-  s.add_runtime_dependency('ruby2_keywords', '~> 0.0.1')
 end


### PR DESCRIPTION
Mustermann already requires at least Ruby 2.6, so there's no need for this dependency anymore.